### PR TITLE
Update DefaultSecDispatcher.java

### DIFF
--- a/src/main/java/org/sonatype/plexus/components/sec/dispatcher/DefaultSecDispatcher.java
+++ b/src/main/java/org/sonatype/plexus/components/sec/dispatcher/DefaultSecDispatcher.java
@@ -61,7 +61,7 @@ implements SecDispatcher
      * 
      * @plexus.configuration default-value="~/.settings-security.xml"
      */
-    protected String _configurationFile = "~/.settings-security.xml";
+    protected String _configurationFile = "~/.m2/settings-security.xml";
 
     // ---------------------------------------------------------------
     public String decrypt( String str )


### PR DESCRIPTION
Default _configurationFile doesn't match what Maven's guide to encryption states as the location of the settings-security.xml file.

see http://maven.apache.org/guides/mini/guide-encryption.html
